### PR TITLE
Allow option names to be repeated accross elements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - composer install --prefer-source

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ensure the config adheres to [the rules](#the-rules).
 
 ## Requirements
 
-- PHP 5.3.0 or later
+- PHP 5.3.0 or later (recommend at least PHP 7.1)
 
 ## Installation
 

--- a/src/GatherContent/ConfigValueObject/Validator.php
+++ b/src/GatherContent/ConfigValueObject/Validator.php
@@ -281,8 +281,6 @@ final class Validator
 
     private function validateUniqueOptionNames($config)
     {
-        $names = array();
-
         foreach ($config as $tab) {
 
             if (count($tab->elements) > 0) {
@@ -290,6 +288,8 @@ final class Validator
                 foreach ($tab->elements as $element) {
 
                     if (in_array($element->type, array('choice_radio', 'choice_checkbox'))) {
+
+                        $names = array();
 
                         foreach ($element->options as $option) {
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1289,14 +1289,12 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         new Config($this->fullConfig);
     }
 
-    public function testItemWideNonUniqueOptionNames()
+    public function testOptionNamesAreAllowedToBeReusedAccrossElements()
     {
-        $this->setExpectedException('GatherContent\ConfigValueObject\ConfigValueException', 'Option names must be unique');
-
         $this->assertEquals('choice_checkbox', $this->fullConfig[1]->elements[3]->type);
 
         $this->fullConfig[1]->elements[0]->options[0]->name = 'op12345';
-        $this->fullConfig[1]->elements[1]->options[1]->name = 'op12345';
+        $this->fullConfig[1]->elements[1]->options[0]->name = 'op12345';
 
         new Config($this->fullConfig);
     }


### PR DESCRIPTION
It is very unlikely that this will break any existing dependency, unless someone is depending on this exception to be thrown when using non-unique option names across different elements in the same Config.